### PR TITLE
Try to fix compatibility for Makie v0.21+ and AlgebraOfGraphics v0.7+

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ KernelDensity = "0.6"
 Makie = "0.20, 0.21"
 StatsBase = "0.34"
 julia = "1.6"
+AlgebraOfGraphics = "0.7, 1"
 
 [extras]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
@@ -23,3 +24,9 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "CairoMakie", "Makie", "Random"]
+
+[weakdeps]
+AlgebraOfGraphics = "cbdf2221-f076-402e-a563-3d30da359d67"
+
+[extensions]
+AlgebraOfGraphicsExt = "AlgebraOfGraphics"

--- a/ext/AlgebraOfGraphicsExt.jl
+++ b/ext/AlgebraOfGraphicsExt.jl
@@ -1,0 +1,13 @@
+module AlgebraOfGraphicsExt
+using SwarmMakie, AlgebraOfGraphics
+import AlgebraOfGraphics: Normal, dictionary, AesColor, AesX, AesY
+
+function AlgebraOfGraphics.aesthetic_mapping(::Type{Beeswarm}, ::Normal, ::Normal)
+    dictionary([
+        1 => AesX,
+        2 => AesY,
+        :color => AesColor,
+    ])
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,7 +30,7 @@ buffer = deepcopy(pixel_points)
             Makie.update_state_before_display!(f)
             Makie.update_state_before_display!(f)
             Makie.update_state_before_display!(f)
-            img = Makie.colorbuffer(f.scene; screen_config = CairoMakie.ScreenConfig(1, 1, :none, true, false))
+            img = Makie.colorbuffer(f.scene; px_per_unit = 1, pt_per_unit = 1, antialias = :none, visible = true, start_renderloop = false)
             # We have a matrix of all colors in the image.  Now, what we do is the following:
             # The color white in RGBf is (1, 1, 1).  For a color to be red, the blue and green components
             # must correspondingly decrease, since the RGBf values cannot exceed 1.


### PR DESCRIPTION
- pass the screen config related arguments in the keyword form rather than a `ScreenConfig` struct to make it compatible with the different defintion of `ScreenConfig` in CairoMakie v0.20- and v0.21+
- add `AlgebraOfGraphicsExt` module to make it compatible with AoG v0.7+ which requires implementing aesthetic mapping for all plots. This is based on the `weakdeps` feature of Julia 1.9+.