### PR TITLE
Give beeswarm plots fixed limits given input data

### DIFF
--- a/docs/src/algorithms.md
+++ b/docs/src/algorithms.md
@@ -19,7 +19,6 @@ ax_plots = [beeswarm(fig[Tuple(idx)...], xs, ys; color = xs, algorithm = algorit
 jitter_plots = getproperty.(ax_plots[2, :], :plot)
 setproperty!.(jitter_plots, :markersize, 7)
 setproperty!.(jitter_plots, :alpha, 0.3)
-Makie.update_state_before_display!(fig)
 fig
 ```
 

--- a/docs/src/examples/examples.jl
+++ b/docs/src/examples/examples.jl
@@ -22,9 +22,6 @@ using PalmerPenguins, DataFrames
 penguins = dropmissing(DataFrame(PalmerPenguins.load()))
 
 f = data(penguins) * mapping(:species, :bill_depth_mm, color=:sex) * visual(Beeswarm) |> draw
-Makie.update_state_before_display!(f.figure)
-Makie.update_state_before_display!(f.figure)
-Makie.update_state_before_display!(f.figure)
 f
 
 # ## SwarmMakie logo
@@ -43,10 +40,6 @@ f.scene.backgroundcolor[] = RGBAf(1,1,1,0)
 a.scene.backgroundcolor[] = RGBAf(1,1,1,0)
 hidedecorations!(a)
 hidespines!(a)
-Makie.update_state_before_display!(f)
-Makie.update_state_before_display!(f)
-Makie.update_state_before_display!(f)
-Makie.update_state_before_display!(f)
 f
 
 # ## Wilkinson's dot histogram

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -35,8 +35,6 @@ iris = dataset("datasets", "iris")
 f = data(iris) * 
     mapping(:Species, :SepalLength; color = :Species) * 
     visual(Beeswarm) |> draw
-Makie.update_state_before_display!(f.figure)
-Makie.update_state_before_display!(f.figure)
 f
 ```
 
@@ -44,4 +42,3 @@ f
 
 If your beeswarms are overlapping, or extending outside the axis area, try decreasing `markersize`.  You can do this by setting `plot.markersize = 6` for example, and then re-displaying the figure.
 
-Generally, the algorithm takes a few iterations of calling `Makie.update_state_before_display!(figure)` to settle in a good configuration.  We are working to fix this.

--- a/src/recipe.jl
+++ b/src/recipe.jl
@@ -81,7 +81,11 @@ function Makie.data_limits(bs::Beeswarm)
     range_1 = if length(categories) == 1
         (only(categories) - 0.5, only(categories) + 0.5)
     else
-        mindiff =  minimum(diff(categories))
+        mindiff = if isnothing(bs.gutter[])
+            minimum(diff(categories))
+        else
+            bs.gutter[]  
+        end
         (first(categories) - mindiff/2, last(categories) + mindiff/2)
     end
     range_2 = extrema(p[2] for p in points)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,8 +28,6 @@ buffer = deepcopy(pixel_points)
             hidedecorations!(a)
             hidespines!(a)
             Makie.update_state_before_display!(f)
-            Makie.update_state_before_display!(f)
-            Makie.update_state_before_display!(f)
             img = Makie.colorbuffer(f.scene; px_per_unit = 1, pt_per_unit = 1, antialias = :none, visible = true, start_renderloop = false)
             # We have a matrix of all colors in the image.  Now, what we do is the following:
             # The color white in RGBf is (1, 1, 1).  For a color to be red, the blue and green components
@@ -53,16 +51,13 @@ buffer = deepcopy(pixel_points)
         # First, we test the regular gutter with multiple categories.
         f, a, p = beeswarm(rand(1:3, 300), randn(300); color = rand(RGBAf, 300), markersize = 20, algorithm = SimpleBeeswarm())
         Makie.update_state_before_display!(f)        
-        Makie.update_state_before_display!(f)
         @test_warn "Gutter threshold exceeded" p.gutter = 0.2
         # Next, we test it in direction y
-        f, a, p = beeswarm(rand(1:3, 300), randn(300); direction = :x, color = rand(RGBAf, 300), markersize = 20, algorithm = SimpleBeeswarm())
-        Makie.update_state_before_display!(f)        
+        f, a, p = beeswarm(rand(1:3, 300), randn(300); direction = :x, color = rand(RGBAf, 300), markersize = 20, algorithm = SimpleBeeswarm())        
         Makie.update_state_before_display!(f)
         @test_warn "Gutter threshold exceeded" p.gutter = 0.2
         # and it shouldn't warn if, when using a lower markersize, the gutter is not reached.
-        f, a, p = beeswarm(rand(1:3, 300), randn(300); direction = :y, color = rand(RGBAf, 300), markersize = 9, algorithm = SimpleBeeswarm())
-        Makie.update_state_before_display!(f)        
+        f, a, p = beeswarm(rand(1:3, 300), randn(300); direction = :y, color = rand(RGBAf, 300), markersize = 9, algorithm = SimpleBeeswarm())      
         Makie.update_state_before_display!(f)
         @test_nowarn p.gutter = 0.5
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,12 +54,12 @@ buffer = deepcopy(pixel_points)
         f, a, p = beeswarm(rand(1:3, 300), randn(300); color = rand(RGBAf, 300), markersize = 20, algorithm = SimpleBeeswarm())
         Makie.update_state_before_display!(f)        
         Makie.update_state_before_display!(f)
-        @test_warn "Gutter threshold exceeded" p.gutter = 0.5
+        @test_warn "Gutter threshold exceeded" p.gutter = 0.2
         # Next, we test it in direction y
         f, a, p = beeswarm(rand(1:3, 300), randn(300); direction = :x, color = rand(RGBAf, 300), markersize = 20, algorithm = SimpleBeeswarm())
         Makie.update_state_before_display!(f)        
         Makie.update_state_before_display!(f)
-        @test_warn "Gutter threshold exceeded" p.gutter = 0.5
+        @test_warn "Gutter threshold exceeded" p.gutter = 0.2
         # and it shouldn't warn if, when using a lower markersize, the gutter is not reached.
         f, a, p = beeswarm(rand(1:3, 300), randn(300); direction = :y, color = rand(RGBAf, 300), markersize = 9, algorithm = SimpleBeeswarm())
         Makie.update_state_before_display!(f)        


### PR DESCRIPTION
Currently, whenever you call `autolimits!` on an axis with a beeswarm plot in it, you get a different result, because it takes the limits of the current scatter plot, but the algorithm finds a new result given those new limits.

I think it makes more sense to pick fixed limits and then adjust axis size or marker size if that's not enough space. You don't get "more" space for the beeswarm anyway by expanding limits, as the extent depends only on screen space.

This PR simply uses the heuristic that having the same space available for each swarm looks good, so it sets data limits that way. If swarms extend out of an Axis, that probably means that they also overlap each other in the middle anyway. So you're unlikely to get a better image by deviating from the heuristic.