### PR TITLE
support vec markersize

### DIFF
--- a/src/algorithms/jitter.jl
+++ b/src/algorithms/jitter.jl
@@ -62,7 +62,12 @@ function calculate!(buffer::AbstractVector{<: Point2}, alg::JitterAlgorithm, pos
 	ys = last.(positions)
 	for x_val in unique(xs)
 		group = xs .== x_val
-		@views buffer[group] .= Point2f.(xs[group] .+ create_jitter_array(ys[group], alg) .* markersize, ys[group])
+        ms = if markersize isa Number
+            markersize
+        else
+            view(markersize, group)
+        end
+		@views buffer[group] .= Point2f.(xs[group] .+ create_jitter_array(ys[group], alg) .* ms, ys[group])
 	end
 end
 

--- a/src/algorithms/jitter.jl
+++ b/src/algorithms/jitter.jl
@@ -61,12 +61,15 @@ function calculate!(buffer::AbstractVector{<: Point2}, alg::JitterAlgorithm, pos
 	xs = first.(positions)
 	ys = last.(positions)
 	for x_val in unique(xs)
+		# Isolate the indices of this particular group
 		group = xs .== x_val
-        ms = if markersize isa Number
-            markersize
-        else
-            view(markersize, group)
-        end
+		# Extract the marker size
+	        ms = if markersize isa Number
+	            markersize
+	        else
+	            view(markersize, group)
+	        end
+		# Assign the jittered values to the buffer
 		@views buffer[group] .= Point2f.(xs[group] .+ create_jitter_array(ys[group], alg) .* ms, ys[group])
 	end
 end

--- a/src/algorithms/simple.jl
+++ b/src/algorithms/simple.jl
@@ -24,7 +24,6 @@ function calculate!(buffer::AbstractVector{<: Point2}, alg::SimpleBeeswarm, posi
     @debug "Calculating..."
     ys = last.(positions)
     xs = first.(positions)
-
     for x_val in unique(xs)
         group = findall(==(x_val), xs)
         view_ys = view(ys, group)
@@ -34,7 +33,8 @@ function calculate!(buffer::AbstractVector{<: Point2}, alg::SimpleBeeswarm, posi
             ms = if markersize isa Number
                 markersize
             else
-                only(unique(@view markersize[group]))
+                view_ms = view(markersize, group)
+                maximum(view_ms)
             end
             xs[group] .= simple_xs(view_ys, ms, side)
         end

--- a/src/algorithms/simple.jl
+++ b/src/algorithms/simple.jl
@@ -31,7 +31,12 @@ function calculate!(buffer::AbstractVector{<: Point2}, alg::SimpleBeeswarm, posi
         if isempty(view_ys)
             continue
         else
-            xs[group] .= simple_xs(view_ys, markersize, side)
+            ms = if markersize isa Number
+                markersize
+            else
+                only(unique(@view markersize[group]))
+            end
+            xs[group] .= simple_xs(view_ys, ms, side)
         end
     end
     

--- a/src/algorithms/simple2.jl
+++ b/src/algorithms/simple2.jl
@@ -11,10 +11,21 @@ function calculate!(buffer::AbstractVector{<: Point2}, alg::SimpleBeeswarm2, pos
         view_ys = view(ys, group)
         perm = sortperm(view_ys)
         ys_sorted = view_ys[perm]
+
+        ms = if markersize isa Number
+            markersize
+        else
+            if length(unique(markersize[group])) == 1
+                markersize[group][1]
+            else # this should error
+                markersize[group]
+            end
+        end
+
         if isempty(ys_sorted)
             continue
         else
-            xs[group] .= simple_beeswarm2(ys_sorted, markersize)[invperm(perm)]
+            xs[group] .= simple_beeswarm2(ys_sorted, ms)[invperm(perm)]
         end
     end
     

--- a/src/algorithms/wilkinson.jl
+++ b/src/algorithms/wilkinson.jl
@@ -52,7 +52,13 @@ function calculate!(buffer::AbstractVector{<: Point2}, alg::WilkinsonBeeswarm, p
     ## the beeswarm for each group.  
     for x_val in unique(xs)
         group = findall(==(x_val), xs)
-        wilkinson_kernel!(view(buffer, group), view(positions, group), markersize, side)
+        ms = if markersize isa Number
+            markersize
+        else
+            view_ms = view(markersize, group)
+            maximum(unique(view_ms))
+        end
+        wilkinson_kernel!(view(buffer, group), view(positions, group), ms, side)
     end
     
 end

--- a/src/algorithms/wilkinson.jl
+++ b/src/algorithms/wilkinson.jl
@@ -56,7 +56,7 @@ function calculate!(buffer::AbstractVector{<: Point2}, alg::WilkinsonBeeswarm, p
             markersize
         else
             view_ms = view(markersize, group)
-            maximum(unique(view_ms))
+            maximum(view_ms)
         end
         wilkinson_kernel!(view(buffer, group), view(positions, group), ms, side)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,8 +64,10 @@ buffer = deepcopy(pixel_points)
     @testset "Vector markersizes" begin
         # First, we test the regular gutter with multiple categories.
         xs = rand(1:3, 300)
-        f, a, p = beeswarm(xs, randn(300); color = rand(RGBAf, 300), markersize = xs*2, algorithm = SimpleBeeswarm())
-        Makie.update_state_before_display!(f)
+        for algorithm in [NoBeeswarm(), SimpleBeeswarm(), WilkinsonBeeswarm(), UniformJitter(), PseudorandomJitter(), QuasirandomJitter()]
+            f, a, p = beeswarm(xs, randn(300); color = rand(RGBAf, 300), markersize = xs*2, algorithm)
+            Makie.update_state_before_display!(f)
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,10 @@ using SwarmMakie, Makie, CairoMakie
 using Makie.Colors
 using Test
 using Random
-
 Random.seed!(123)
+
+
+const ALL_ALGORITHMS = [NoBeeswarm(), SimpleBeeswarm(), SimpleBeeswarm2(), WilkinsonBeeswarm(), UniformJitter(), PseudorandomJitter(), QuasirandomJitter()]
 
 colors = RGBf.(LinRange(0, 1, 1000), 0, 0)
 
@@ -15,14 +17,14 @@ buffer = deepcopy(pixel_points)
 
 @testset "SwarmMakie.jl" begin
     @testset "Algorithms run without error" begin
-        for algorithm in [NoBeeswarm(), SimpleBeeswarm(), WilkinsonBeeswarm(), UniformJitter(), PseudorandomJitter(), QuasirandomJitter()]
+        for algorithm in ALL_ALGORITHMS
             @test_nowarn begin
                 SwarmMakie.calculate!(buffer, algorithm, pixel_points, 10, :left)
             end
         end
     end
     @testset "Overlaps" begin
-        for algorithm in [SimpleBeeswarm(), WilkinsonBeeswarm()]
+        for algorithm in [SimpleBeeswarm(), SimpleBeeswarm2(), WilkinsonBeeswarm()]
             # We test how many points are overlapping, proportionately.
             f, a, p = beeswarm(original_points; alpha = 0.5, algorithm, color = :red)
             hidedecorations!(a)
@@ -49,22 +51,22 @@ buffer = deepcopy(pixel_points)
     end
     @testset "Gutters" begin
         # First, we test the regular gutter with multiple categories.
-        f, a, p = beeswarm(rand(1:3, 300), randn(300); color = rand(RGBAf, 300), markersize = 20, algorithm = SimpleBeeswarm())
+        f, a, p = beeswarm(rand(1:3, 300), randn(300); color = rand(RGBAf, 300), markersize = 20, algorithm = SimpleBeeswarm2())
         Makie.update_state_before_display!(f)        
         @test_warn "Gutter threshold exceeded" p.gutter = 0.2
         # Next, we test it in direction y
-        f, a, p = beeswarm(rand(1:3, 300), randn(300); direction = :x, color = rand(RGBAf, 300), markersize = 20, algorithm = SimpleBeeswarm())        
+        f, a, p = beeswarm(rand(1:3, 300), randn(300); direction = :x, color = rand(RGBAf, 300), markersize = 20, algorithm = SimpleBeeswarm2())        
         Makie.update_state_before_display!(f)
         @test_warn "Gutter threshold exceeded" p.gutter = 0.2
         # and it shouldn't warn if, when using a lower markersize, the gutter is not reached.
-        f, a, p = beeswarm(rand(1:3, 300), randn(300); direction = :y, color = rand(RGBAf, 300), markersize = 9, algorithm = SimpleBeeswarm())      
+        f, a, p = beeswarm(rand(1:3, 300), randn(300); direction = :y, color = rand(RGBAf, 300), markersize = 9, algorithm = SimpleBeeswarm2())      
         Makie.update_state_before_display!(f)
         @test_nowarn p.gutter = 0.5
     end
     @testset "Vector markersizes" begin
         # First, we test the regular gutter with multiple categories.
         xs = rand(1:3, 300)
-        for algorithm in [NoBeeswarm(), SimpleBeeswarm(), WilkinsonBeeswarm(), UniformJitter(), PseudorandomJitter(), QuasirandomJitter()]
+        for algorithm in ALL_ALGORITHMS
             f, a, p = beeswarm(xs, randn(300); color = rand(RGBAf, 300), markersize = xs*2, algorithm)
             Makie.update_state_before_display!(f)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,6 +61,12 @@ buffer = deepcopy(pixel_points)
         Makie.update_state_before_display!(f)
         @test_nowarn p.gutter = 0.5
     end
+    @testset "Vector markersizes" begin
+        # First, we test the regular gutter with multiple categories.
+        xs = rand(1:3, 300)
+        f, a, p = beeswarm(xs, randn(300); color = rand(RGBAf, 300), markersize = xs*2, algorithm = SimpleBeeswarm())
+        Makie.update_state_before_display!(f)
+    end
 end
 
 # TODO: 


### PR DESCRIPTION
- **support vector markersize**
- **add test**

fix #29

```julia
julia> xs = rand(1:4, 500);

julia> ys = randn(500);

julia> beeswarm(xs, ys; color = xs, markersize=xs.*2)
```
![image](https://github.com/user-attachments/assets/7a1f9de2-b5cf-4b67-a31f-99d5773ffeef)


cc. @HelloYanming for spotting lack of this feature in Seaborn
